### PR TITLE
Add Endpoints for Item Entity

### DIFF
--- a/src/main/java/com/api/v2/tastytech/controller/CategoryItemController.java
+++ b/src/main/java/com/api/v2/tastytech/controller/CategoryItemController.java
@@ -1,0 +1,62 @@
+package com.api.v2.tastytech.controller;
+
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.service.ItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/category")
+public class CategoryItemController {
+
+    private final ItemService itemService;
+
+    public CategoryItemController(ItemService itemService) {
+        this.itemService = itemService;
+    }
+
+    //POST: category/{id}/item
+    @Operation(summary = "CREATE new category item")
+    @PostMapping("/{categoryId}/item")
+    public ResponseEntity<ItemOutputDto> save(@PathVariable("categoryId") Long id, @RequestBody ItemInputDto itemDto) throws Exception {
+        ItemOutputDto item = itemService.save(id, itemDto);
+        return new ResponseEntity<>(item, HttpStatus.CREATED);
+    }
+
+    //GET: category/{id}/item
+    @Operation(summary = "GET all items by category's id")
+    @GetMapping("/{categoryId}/item")
+    public ResponseEntity<List<ItemOutputDto>> findAllItems(@PathVariable("categoryId") Long id) throws Exception {
+        List<ItemOutputDto> items = itemService.getAll(id);
+        return new ResponseEntity<>(items, HttpStatus.OK);
+    }
+
+    //GET: category/{id}/item/{id}
+    @Operation(summary = "GET item by its id")
+    @GetMapping("/{categoryId}/item/{id}")
+    public ResponseEntity<ItemOutputDto> findCategoryById(@PathVariable("id") Long id) throws Exception {
+        ItemOutputDto item = itemService.getById(id);
+        return new ResponseEntity<>(item, HttpStatus.OK);
+    }
+
+    //PUT: category/{id}/item/{id}
+    @Operation(summary = "UPDATE category item")
+    @PutMapping("/{categoryId}/item/{id}")
+    public ResponseEntity<ItemOutputDto> update(@PathVariable("id") Long id, ItemInputDto itemDto) throws Exception {
+        ItemOutputDto item = itemService.update(id, itemDto);
+        return new ResponseEntity<>(item, HttpStatus.OK);
+    }
+
+    //DELETE: category/{id}/item/{id}
+    @Operation(summary = "DELETE item by its id")
+    @DeleteMapping("/{categoryId}/item/{id}")
+    public ResponseEntity<String> deleteCategory(@PathVariable("id") Long id) throws Exception {
+        itemService.delete(id);
+        return new ResponseEntity<>("Item successfully removed!", HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/converter/impl/ItemConverter.java
+++ b/src/main/java/com/api/v2/tastytech/converter/impl/ItemConverter.java
@@ -1,0 +1,63 @@
+package com.api.v2.tastytech.converter.impl;
+
+import com.api.v2.tastytech.converter.DtoEntityConverter;
+import com.api.v2.tastytech.domain.Item;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class ItemConverter implements DtoEntityConverter<ItemInputDto, ItemOutputDto, Item> {
+
+    @Autowired
+    private ItemTranslationConverter itemTranslationConverter;
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Override
+    public ItemOutputDto toDto(Item entity) {
+
+        List<ItemTranslationOutputDto> translations = new ArrayList<>();
+
+        if(entity.getTranslations() != null && !entity.getTranslations().isEmpty()) {
+            translations = entity.getTranslations()
+                    .stream()
+                    .map(e -> itemTranslationConverter.toDto(e))
+                    .toList();
+        }
+        return new ItemOutputDto(
+                entity.getId(),
+                entity.getPrice(),
+                translations
+        );
+    }
+
+    @Override
+    public Item toEntity(ItemInputDto input) throws Exception {
+
+        List<ItemTranslation> translations = new ArrayList<>();
+        if(input.getTranslations() != null && !input.getTranslations().isEmpty()) {
+            for(ItemTranslationInputDto tr: input.getTranslations()) {
+                ItemTranslation translation = itemTranslationConverter.toEntity(tr);
+                translations.add(translation);
+            }
+        }
+
+        return new Item(
+                null,
+                sdf.parse(sdf.format(new Date())),
+                sdf.parse(sdf.format(new Date())),
+                input.getPrice(),
+                null,
+                translations
+        );
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/converter/impl/ItemTranslationConverter.java
+++ b/src/main/java/com/api/v2/tastytech/converter/impl/ItemTranslationConverter.java
@@ -1,0 +1,39 @@
+package com.api.v2.tastytech.converter.impl;
+
+import com.api.v2.tastytech.converter.DtoEntityConverter;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Component
+public class ItemTranslationConverter implements DtoEntityConverter<ItemTranslationInputDto, ItemTranslationOutputDto, ItemTranslation> {
+
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Override
+    public ItemTranslationOutputDto toDto(ItemTranslation entity) {
+        return new ItemTranslationOutputDto(
+                entity.getName(),
+                entity.getDescription(),
+                entity.getLanguage().getLanguage(),
+                entity.getLanguage().getCulturalCode()
+        );
+    }
+
+    @Override
+    public ItemTranslation toEntity(ItemTranslationInputDto input) throws Exception {
+        return new ItemTranslation(
+                null,
+                sdf.parse(sdf.format(new Date())),
+                sdf.parse(sdf.format(new Date())),
+                input.getItem(),
+                input.getDescription(),
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/dto/ItemInputDto.java
+++ b/src/main/java/com/api/v2/tastytech/dto/ItemInputDto.java
@@ -1,0 +1,48 @@
+package com.api.v2.tastytech.dto;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+public class ItemInputDto implements Serializable {
+
+    private Double price;
+    private List<ItemTranslationInputDto> translations;
+
+    public ItemInputDto() {
+    }
+
+    public ItemInputDto(Double price, List<ItemTranslationInputDto> translations) {
+        this.price = price;
+        this.translations = translations;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public List<ItemTranslationInputDto> getTranslations() {
+        return translations;
+    }
+
+    public void setTranslations(List<ItemTranslationInputDto> translations) {
+        this.translations = translations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ItemInputDto that)) return false;
+        return Objects.equals(price, that.price)
+                && Objects.equals(translations, that.translations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(price, translations);
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/dto/ItemOutputDto.java
+++ b/src/main/java/com/api/v2/tastytech/dto/ItemOutputDto.java
@@ -1,0 +1,59 @@
+package com.api.v2.tastytech.dto;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+public class ItemOutputDto implements Serializable {
+
+    private Long id;
+    private Double price;
+    private List<ItemTranslationOutputDto> translations;
+
+    public ItemOutputDto() {
+    }
+
+    public ItemOutputDto(Long id, Double price, List<ItemTranslationOutputDto> translations) {
+        this.id = id;
+        this.price = price;
+        this.translations = translations;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public List<ItemTranslationOutputDto> getTranslations() {
+        return translations;
+    }
+
+    public void setTranslations(List<ItemTranslationOutputDto> translations) {
+        this.translations = translations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ItemOutputDto that)) return false;
+        return Objects.equals(id, that.id)
+                && Objects.equals(price, that.price)
+                && Objects.equals(translations, that.translations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, price, translations);
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/dto/ItemTranslationInputDto.java
+++ b/src/main/java/com/api/v2/tastytech/dto/ItemTranslationInputDto.java
@@ -1,0 +1,58 @@
+package com.api.v2.tastytech.dto;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ItemTranslationInputDto implements Serializable {
+
+    private String item;
+    private String description;
+    private String culturalCode;
+
+    public ItemTranslationInputDto() {
+    }
+
+    public ItemTranslationInputDto(String item, String description, String culturalCode) {
+        this.item = item;
+        this.description = description;
+        this.culturalCode = culturalCode;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public void setItem(String item) {
+        this.item = item;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCulturalCode() {
+        return culturalCode;
+    }
+
+    public void setCulturalCode(String culturalCode) {
+        this.culturalCode = culturalCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ItemTranslationInputDto that)) return false;
+        return Objects.equals(item, that.item)
+                && Objects.equals(description, that.description)
+                && Objects.equals(culturalCode, that.culturalCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(item, description, culturalCode);
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/dto/ItemTranslationOutputDto.java
+++ b/src/main/java/com/api/v2/tastytech/dto/ItemTranslationOutputDto.java
@@ -1,0 +1,69 @@
+package com.api.v2.tastytech.dto;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ItemTranslationOutputDto implements Serializable {
+
+    private String item;
+    private String description;
+    private String language;
+    private String culturalCode;
+
+    public ItemTranslationOutputDto() {
+    }
+
+    public ItemTranslationOutputDto(String item, String description, String language, String culturalCode) {
+        this.item = item;
+        this.description = description;
+        this.language = language;
+        this.culturalCode = culturalCode;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public void setItem(String item) {
+        this.item = item;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getCulturalCode() {
+        return culturalCode;
+    }
+
+    public void setCulturalCode(String culturalCode) {
+        this.culturalCode = culturalCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ItemTranslationOutputDto that)) return false;
+        return Objects.equals(item, that.item)
+                && Objects.equals(description, that.description)
+                && Objects.equals(language, that.language)
+                && Objects.equals(culturalCode, that.culturalCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(item, description, language, culturalCode);
+    }
+}

--- a/src/main/java/com/api/v2/tastytech/repository/CategoryRepository.java
+++ b/src/main/java/com/api/v2/tastytech/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.api.v2.tastytech.repository;
+
+import com.api.v2.tastytech.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/api/v2/tastytech/repository/ItemRepository.java
+++ b/src/main/java/com/api/v2/tastytech/repository/ItemRepository.java
@@ -1,0 +1,12 @@
+package com.api.v2.tastytech.repository;
+
+import com.api.v2.tastytech.domain.Category;
+import com.api.v2.tastytech.domain.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findItemsByCategory(Category category);
+}

--- a/src/main/java/com/api/v2/tastytech/repository/ItemTranslationRepository.java
+++ b/src/main/java/com/api/v2/tastytech/repository/ItemTranslationRepository.java
@@ -1,0 +1,7 @@
+package com.api.v2.tastytech.repository;
+
+import com.api.v2.tastytech.domain.ItemTranslation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemTranslationRepository extends JpaRepository<ItemTranslation, Long> {
+}

--- a/src/main/java/com/api/v2/tastytech/service/ItemService.java
+++ b/src/main/java/com/api/v2/tastytech/service/ItemService.java
@@ -1,0 +1,15 @@
+package com.api.v2.tastytech.service;
+
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+
+import java.util.List;
+
+public interface ItemService {
+
+    ItemOutputDto save(Long id, ItemInputDto itemDto) throws Exception;
+    List<ItemOutputDto> getAll(Long id) throws Exception;
+    ItemOutputDto getById(Long id) throws Exception;
+    ItemOutputDto update(Long id, ItemInputDto itemDto) throws Exception;
+    void delete(Long id) throws Exception;
+}

--- a/src/main/java/com/api/v2/tastytech/service/impl/ItemServiceImpl.java
+++ b/src/main/java/com/api/v2/tastytech/service/impl/ItemServiceImpl.java
@@ -1,0 +1,103 @@
+package com.api.v2.tastytech.service.impl;
+
+import com.api.v2.tastytech.converter.impl.ItemConverter;
+import com.api.v2.tastytech.domain.Category;
+import com.api.v2.tastytech.domain.Item;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.domain.Language;
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.repository.CategoryRepository;
+import com.api.v2.tastytech.repository.ItemRepository;
+import com.api.v2.tastytech.repository.ItemTranslationRepository;
+import com.api.v2.tastytech.repository.LanguageRepository;
+import com.api.v2.tastytech.service.ItemService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ItemServiceImpl implements ItemService {
+
+    private final ItemRepository itemRepository;
+    private final CategoryRepository categoryRepository;
+    private final LanguageRepository languageRepository;
+    private final ItemTranslationRepository itemTranslationRepository;
+    private final ItemConverter itemConverter;
+
+    public ItemServiceImpl(ItemRepository itemRepository, CategoryRepository categoryRepository, LanguageRepository languageRepository,
+                           ItemTranslationRepository itemTranslationRepository, ItemConverter itemConverter) {
+        this.itemRepository = itemRepository;
+        this.categoryRepository = categoryRepository;
+        this.languageRepository = languageRepository;
+        this.itemTranslationRepository = itemTranslationRepository;
+        this.itemConverter = itemConverter;
+    }
+
+    @Override
+    public ItemOutputDto save(Long id, ItemInputDto itemDto) throws Exception {
+        Optional<Category> category = categoryRepository.findById(id);
+        if(category.isEmpty()) {
+            throw new Exception("Selected category doesn't exist!");
+        }
+
+        Item itemForSave = itemConverter.toEntity(itemDto);
+        itemForSave.setCategory(category.get());
+        Item savedItem = itemRepository.save(itemForSave);
+
+        if(itemForSave.getTranslations() != null && !itemForSave.getTranslations().isEmpty()) {
+            this.saveItemTranslations(itemDto, itemForSave.getTranslations(), savedItem);
+        }
+        return itemConverter.toDto(savedItem);
+    }
+
+    @Override
+    public List<ItemOutputDto> getAll(Long id) throws Exception {
+        Optional<Category> category = categoryRepository.findById(id);
+        if(category.isEmpty()) {
+            throw new Exception("Selected category doesn't exist!");
+        }
+        return itemRepository
+                .findItemsByCategory(category.get())
+                .stream()
+                .map(itemConverter::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ItemOutputDto getById(Long id) throws Exception {
+        Optional<Item> item = itemRepository.findById(id);
+        if (item.isEmpty()) {
+            throw new Exception("Item doesn't exist!");
+        }
+        return itemConverter.toDto(item.get());
+    }
+
+    @Override
+    public ItemOutputDto update(Long id, ItemInputDto itemDto) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void delete(Long id) throws Exception {
+        Optional<Item> item = itemRepository.findById(id);
+        if (item.isEmpty()) {
+            throw new Exception("Item doesn't exist!");
+        }
+        itemRepository.delete(item.get());
+    }
+
+    private void saveItemTranslations(ItemInputDto itemDto, List<ItemTranslation> translations, Item item) throws Exception {
+        for(int i = 0; i < itemDto.getTranslations().size(); i++) {
+            translations.get(i).setItem(item);
+            Optional<Language> language = languageRepository.findLanguageByCulturalCode(itemDto.getTranslations().get(i).getCulturalCode());
+            if (language.isEmpty()) {
+                throw new Exception("Unknown language!");
+            }
+            translations.get(i).setLanguage(language.get());
+            itemTranslationRepository.save(translations.get(i));
+        }
+    }
+}

--- a/src/test/java/com/api/v2/tastytech/controller/CategoryItemControllerTests.java
+++ b/src/test/java/com/api/v2/tastytech/controller/CategoryItemControllerTests.java
@@ -1,0 +1,188 @@
+package com.api.v2.tastytech.controller;
+
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import com.api.v2.tastytech.service.ItemService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@WebMvcTest(CategoryItemController.class)
+public class CategoryItemControllerTests {
+
+    @MockBean
+    private ItemService itemService;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objMapper;
+
+    @Test
+    public void createNewCategoryItemSuccessfullyTest() throws Exception {
+        ItemInputDto itemInput = new ItemInputDto(4.50, Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci napitak", "sr_SR")
+        ));
+        ItemOutputDto itemOutput = new ItemOutputDto(34l, 4.50, Arrays.asList(
+                new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                new ItemTranslationOutputDto("limunada", "osvezavajuci napitak", "serbian", "sr_SR")
+        ));
+
+        Mockito.when(itemService.save(45l, itemInput)).thenReturn(itemOutput);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/category/{categoryId}/item", 45l)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objMapper.writeValueAsString(itemInput)))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id", CoreMatchers.equalTo(itemOutput.getId().intValue())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.price", CoreMatchers.equalTo(itemOutput.getPrice())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[0].item", CoreMatchers.equalTo("lemonade")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[0].description", CoreMatchers.equalTo("fresh summer drink")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[0].language", CoreMatchers.equalTo("english")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[0].culturalCode", CoreMatchers.equalTo("en_EN")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[1].item", CoreMatchers.equalTo("limunada")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[1].description", CoreMatchers.equalTo("osvezavajuci napitak")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[1].language", CoreMatchers.equalTo("serbian")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.translations[1].culturalCode", CoreMatchers.equalTo("sr_SR")));
+
+        Mockito.verify(itemService, Mockito.times(1)).save(45l, itemInput);
+    }
+
+    @Test
+    public void saveCategoryItemCategoryDoesntExistTest() throws Exception {
+        ItemInputDto itemInput = new ItemInputDto(4.50, Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci napitak", "sr_SR")
+        ));
+
+        Mockito.doThrow(new Exception("Selected category doesn't exist!")).when(itemService).save(45l, itemInput);
+
+        var res = mockMvc.perform(MockMvcRequestBuilders.post("/category/{categoryId}/item", 45l)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objMapper.writeValueAsString(itemInput)))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
+
+        Assertions.assertEquals("{\"message\":\"Selected category doesn't exist!\"}", res);
+    }
+
+    @Test
+    public void getAllItemsSuccessfullyTest() throws Exception {
+        List<ItemOutputDto> itemsDto = Arrays.asList(
+                new ItemOutputDto(34l, 4.50, Arrays.asList(
+                        new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                        new ItemTranslationOutputDto("limunada", "", "serbian", "sr_SR")
+                )),
+                new ItemOutputDto(36l, 9.10, Arrays.asList(
+                        new ItemTranslationOutputDto("orange juice", "", "english", "en_EN"),
+                        new ItemTranslationOutputDto("sok od pomorandze", "", "serbian", "sr_SR")
+                ))
+        );
+
+        Mockito.when(itemService.getAll(3l)).thenReturn(itemsDto);
+
+        MvcResult res = mockMvc.perform(MockMvcRequestBuilders.get("/category/{categoryId}/item", 3l))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+        List<ItemOutputDto> receivedItems = objMapper.readValue(res.getResponse().getContentAsString(),
+                new TypeReference<List<ItemOutputDto>>() {
+                });
+        Assertions.assertArrayEquals(itemsDto.toArray(), receivedItems.toArray());
+    }
+
+    @Test
+    public void getAllItemsEmptyListTest() throws Exception {
+        List<ItemOutputDto> itemsDto = new ArrayList<>();
+
+        Mockito.when(itemService.getAll(2l)).thenReturn(itemsDto);
+
+        MvcResult res = mockMvc.perform(MockMvcRequestBuilders.get("/category/{categoryId}/item", 2l))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+        List<ItemOutputDto> receivedItems = objMapper.readValue(res.getResponse().getContentAsString(),
+                new TypeReference<List<ItemOutputDto>>() {
+                });
+        Assertions.assertTrue(receivedItems.isEmpty());
+    }
+
+    @Test
+    public void getCategoryByIdSuccessfullyTest() throws Exception {
+        ItemOutputDto itemDto = new ItemOutputDto(34l, 4.50, Arrays.asList(
+                new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                new ItemTranslationOutputDto("limunada", "osvezavajuci napitak", "serbian", "sr_SR")
+        ));
+
+        Mockito.when(itemService.getById(34l)).thenReturn(itemDto);
+
+        MvcResult res = mockMvc.perform(MockMvcRequestBuilders.get("/category/{categoryId}/item/{id}", 5l, 34l))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        ItemOutputDto receivedItem = objMapper.readValue(res.getResponse().getContentAsString(),
+                new TypeReference<ItemOutputDto>() {
+                });
+
+        Assertions.assertEquals(receivedItem, itemDto);
+    }
+
+    @Test
+    public void getItemByIdNullReturnedTest() throws Exception {
+
+        Mockito.when(itemService.getById(34l)).thenReturn(null);
+
+        MvcResult res = mockMvc.perform(MockMvcRequestBuilders.get("/category/{categoryId}/item/{id}", 5l, 34l))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        String content = res.getResponse().getContentAsString();
+
+        Assertions.assertTrue(content.isEmpty() || content.isBlank() || content.equals("null"));
+    }
+
+    @Test
+    public void getItemByIdFailureTest() throws Exception {
+
+        Mockito.when(itemService.getById(1l)).thenThrow(Exception.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/category/{categoryId}/item/{id}", 5l, 1l))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    public void deleteItemSuccessfullyTest() throws Exception {
+        Mockito.doNothing().when(itemService).delete(65l);
+
+        MvcResult res = mockMvc.perform(MockMvcRequestBuilders.delete("/category/{categoryId}/item/{id}", 22l, 65l))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        String content = res.getResponse().getContentAsString();
+
+        Assertions.assertEquals("Item successfully removed!", content);
+    }
+
+    @Test
+    public void deleteItemFailureTest() throws Exception {
+        Mockito.doThrow(new Exception("Item doesn't exist!")).when(itemService).delete(1l);
+
+        var res = mockMvc.perform(MockMvcRequestBuilders.delete("/category/{categoryId}/item/{id}", 22l, 1l))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
+
+        Assertions.assertEquals("{\"message\":\"Item doesn't exist!\"}", res);
+    }
+}

--- a/src/test/java/com/api/v2/tastytech/converter/ItemConverterTests.java
+++ b/src/test/java/com/api/v2/tastytech/converter/ItemConverterTests.java
@@ -1,0 +1,152 @@
+package com.api.v2.tastytech.converter;
+
+import com.api.v2.tastytech.converter.impl.ItemConverter;
+import com.api.v2.tastytech.converter.impl.ItemTranslationConverter;
+import com.api.v2.tastytech.domain.Item;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.domain.Language;
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+@SpringBootTest
+public class ItemConverterTests {
+
+    @Autowired
+    private ItemConverter itemConverter;
+    @MockBean
+    private ItemTranslationConverter itemTranslationConverter;
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Test
+    public void toDtoTest() {
+        List<ItemTranslation> translations = Arrays.asList(
+                new ItemTranslation(1l, new Date(), new Date(), "lemonade", "fresh summer drink",
+                        new Language(1l, "english", "en_US"), null),
+                new ItemTranslation(2l, new Date(), new Date(), "limunada", "osvezavajuci letnji napitak",
+                        new Language(2l, "serbian", "sr_SR"), null)
+        );
+        List<ItemTranslationOutputDto> translationsDto = Arrays.asList(
+                new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_US"),
+                new ItemTranslationOutputDto("limunada", "osvezavajuci letnji napitak", "serbian", "sr_SR")
+        );
+        Item item = new Item(1l, new Date(), new Date(), 15.80, null, translations);
+        ItemOutputDto itemDto = new ItemOutputDto(1l, 15.80, translationsDto);
+
+        Mockito.when(itemTranslationConverter.toDto(ArgumentMatchers.any(ItemTranslation.class))).thenAnswer(invocation -> {
+            ItemTranslation entity = invocation.getArgument(0);
+            return new ItemTranslationOutputDto(entity.getName(), entity.getDescription(), entity.getLanguage().getLanguage(), entity.getLanguage().getCulturalCode());
+        });
+
+        ItemOutputDto result = itemConverter.toDto(item);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(itemDto, result);
+    }
+
+    @Test
+    public void toDtoItemTranslationsIsNullTest() {
+        Item item = new Item(1l, new Date(), new Date(), 15.80, null, null);
+        ItemOutputDto itemDto = new ItemOutputDto(1l, 15.80, new ArrayList<>());
+
+        ItemOutputDto result = itemConverter.toDto(item);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(itemDto, result);
+    }
+
+    @Test
+    public void toDtoItemTranslationsIsEmptyTest() {
+        Item item = new Item(1l, new Date(), new Date(), 15.80, null, new ArrayList<>());
+        ItemOutputDto itemDto = new ItemOutputDto(1l, 15.80, new ArrayList<>());
+
+        ItemOutputDto result = itemConverter.toDto(item);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(itemDto, result);
+    }
+
+    @Test
+    public void toDtoEntityItemIsNullTest() {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            itemConverter.toDto(null);
+        });
+
+        Assertions.assertInstanceOf(NullPointerException.class, ex);
+    }
+
+    @Test
+    public void toEntityTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        List<ItemTranslationInputDto> translationsDto = Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci letnji napitak", "sr_SR")
+        );
+        List<ItemTranslation> translations = Arrays.asList(
+                new ItemTranslation(null, formatedDate, formatedDate, "lemonade", "fresh summer drink", null, null),
+                new ItemTranslation(null, formatedDate, formatedDate, "limunada", "osvezavajuci letnji napitak", null, null)
+        );
+        ItemInputDto itemDto = new ItemInputDto(14.80, translationsDto);
+        Item item = new Item(null, formatedDate, formatedDate, 14.80, null, translations);
+
+        Mockito.when(itemTranslationConverter.toEntity(ArgumentMatchers.any(ItemTranslationInputDto.class))).thenAnswer(invocation -> {
+            ItemTranslationInputDto dto = invocation.getArgument(0);
+            return new ItemTranslation(null, formatedDate, formatedDate, dto.getItem(), dto.getDescription(), null, null);
+        });
+
+        Item result = itemConverter.toEntity(itemDto);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(item, result);
+    }
+
+    @Test
+    public void toEntityItemTranslationDtoIsNullTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        ItemInputDto itemDto = new ItemInputDto(14.80, null);
+        Item item = new Item(null, formatedDate, formatedDate, 14.80, null, new ArrayList<>());
+
+        Item result = itemConverter.toEntity(itemDto);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(item, result);
+    }
+
+    @Test
+    public void toEntityItemTranslationDtoIsEmptyTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        ItemInputDto itemDto = new ItemInputDto(14.80, new ArrayList<>());
+        Item item = new Item(null, formatedDate, formatedDate, 14.80, null, new ArrayList<>());
+
+        Item result = itemConverter.toEntity(itemDto);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(item, result);
+    }
+
+    @Test
+    public void toEntityItemDtoIsNullTest() {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            itemConverter.toEntity(null);
+        });
+
+        Assertions.assertInstanceOf(NullPointerException.class, ex);
+    }
+}

--- a/src/test/java/com/api/v2/tastytech/converter/ItemTranslationConverterTests.java
+++ b/src/test/java/com/api/v2/tastytech/converter/ItemTranslationConverterTests.java
@@ -1,0 +1,68 @@
+package com.api.v2.tastytech.converter;
+
+import com.api.v2.tastytech.converter.impl.ItemTranslationConverter;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.domain.Language;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@SpringBootTest
+public class ItemTranslationConverterTests {
+
+    @Autowired
+    private ItemTranslationConverter itemTranslationConverter;
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Test
+    public void toDtoTest() {
+        ItemTranslation translation = new ItemTranslation(1l, new Date(), new Date(), "lemonade",
+                "fresh summer drink", new Language(1l, "english", "en_US"), null);
+        ItemTranslationOutputDto translationDto = new ItemTranslationOutputDto("lemonade", "fresh summer drink",
+                "english", "en_US");
+
+        ItemTranslationOutputDto result = itemTranslationConverter.toDto(translation);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(translationDto, result);
+    }
+
+    @Test
+    public void toDtoEntityItemTranslationIsNullTest() {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            itemTranslationConverter.toDto(null);
+        });
+
+        Assertions.assertInstanceOf(NullPointerException.class, ex);
+    }
+
+    @Test
+    public void toEntityTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        ItemTranslationInputDto translationDto = new ItemTranslationInputDto("lemonade",
+                "fresh summer drink", "en_US");
+        ItemTranslation translation = new ItemTranslation(null, formatedDate, formatedDate, "lemonade",
+                "fresh summer drink", null, null);
+
+        ItemTranslation result = itemTranslationConverter.toEntity(translationDto);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(translation, result);
+    }
+
+    @Test
+    public void toEntityBrandDtoIsNullTest() {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            itemTranslationConverter.toEntity(null);
+        });
+
+        Assertions.assertInstanceOf(NullPointerException.class, ex);
+    }
+}

--- a/src/test/java/com/api/v2/tastytech/repository/ItemRepositoryTests.java
+++ b/src/test/java/com/api/v2/tastytech/repository/ItemRepositoryTests.java
@@ -1,0 +1,42 @@
+package com.api.v2.tastytech.repository;
+
+import com.api.v2.tastytech.domain.Category;
+import com.api.v2.tastytech.domain.Item;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.domain.Language;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+@SpringBootTest
+public class ItemRepositoryTests {
+
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    public void findItemsByCategorySuccessfullyTest() {
+        Category category = categoryRepository.save(new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null));
+        List<Item> items = Arrays.asList(
+                new Item(34l, new Date(), new Date(), 4.50, category, Arrays.asList(
+                        new ItemTranslation(null, new Date(), new Date(), "lemonade", "fresh summer drink",
+                                new Language(1l, "english", "en_EN"), null),
+                        new ItemTranslation(null, new Date(), new Date(), "limunada", "",
+                                new Language(1l, "serbian", "sr_SR"), null)
+                )),
+                new Item(36l, new Date(), new Date(), 9.10, category, Arrays.asList(
+                        new ItemTranslation(null, new Date(), new Date(), "orange juice", "",
+                                new Language(1l, "english", "en_EN"), null),
+                        new ItemTranslation(null, new Date(), new Date(), "sok od pomorandze", "",
+                                new Language(1l, "serbian", "sr_SR"), null)
+                ))
+        );
+    }
+}

--- a/src/test/java/com/api/v2/tastytech/service/ItemServiceTests.java
+++ b/src/test/java/com/api/v2/tastytech/service/ItemServiceTests.java
@@ -1,0 +1,281 @@
+package com.api.v2.tastytech.service;
+
+import com.api.v2.tastytech.converter.impl.ItemConverter;
+import com.api.v2.tastytech.domain.Category;
+import com.api.v2.tastytech.domain.Item;
+import com.api.v2.tastytech.domain.ItemTranslation;
+import com.api.v2.tastytech.domain.Language;
+import com.api.v2.tastytech.dto.ItemInputDto;
+import com.api.v2.tastytech.dto.ItemOutputDto;
+import com.api.v2.tastytech.dto.ItemTranslationInputDto;
+import com.api.v2.tastytech.dto.ItemTranslationOutputDto;
+import com.api.v2.tastytech.repository.CategoryRepository;
+import com.api.v2.tastytech.repository.ItemRepository;
+import com.api.v2.tastytech.repository.ItemTranslationRepository;
+import com.api.v2.tastytech.repository.LanguageRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@SpringBootTest
+public class ItemServiceTests {
+
+    @Autowired
+    private ItemService itemService;
+    @MockBean
+    private CategoryRepository categoryRepository;
+    @MockBean
+    private ItemConverter itemConverter;
+    @MockBean
+    private ItemRepository itemRepository;
+    @MockBean
+    private ItemTranslationRepository itemTranslationRepository;
+    @MockBean
+    private LanguageRepository languageRepository;
+
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Test
+    public void saveItemSuccessfullyTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+        ItemInputDto itemDto = new ItemInputDto(4.50, Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci napitak", "sr_SR")
+        ));
+        Item itemForSave = new Item(null, formatedDate, formatedDate, 4.50, null, Arrays.asList(
+                new ItemTranslation(null, formatedDate, formatedDate, "lemonade",
+                        "fresh summer drink", null, null),
+                new ItemTranslation(null, formatedDate, formatedDate, "limunada",
+                        "osvezavajuci napitak", null, null)
+        ));
+        Item savedItem = new Item(34l, new Date(),new Date(), 4.50, category, null);
+        ItemOutputDto finalItemDto = new ItemOutputDto(34l, 4.50, Arrays.asList(
+                new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                new ItemTranslationOutputDto("limunada", "osvezavajuci napitak", "serbian", "sr_SR")
+        ));
+
+        Mockito.when(itemConverter.toDto(savedItem)).thenReturn(finalItemDto);
+        Mockito.when(itemTranslationRepository.save(ArgumentMatchers.any(ItemTranslation.class))).thenAnswer(invocationOnMock -> {
+            ItemTranslation translation = invocationOnMock.getArgument(0);
+            return new ItemTranslation(translation.getId(), translation.getCreatedAt(), translation.getUpdatedAt(),
+                    translation.getName(), translation.getDescription(), translation.getLanguage(), translation.getItem());
+        });
+        Mockito.when(languageRepository.findLanguageByCulturalCode(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(new Language(1l, "english", "en_EN")))
+                .thenReturn(Optional.of(new Language(2l, "serbian", "sr_SR")));
+
+        Mockito.when(itemRepository.save(itemForSave)).thenReturn(savedItem);
+        Mockito.when(itemConverter.toEntity(itemDto)).thenReturn(itemForSave);
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.of(category));
+
+        ItemOutputDto result = itemService.save(2l, itemDto);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(finalItemDto, result);
+    }
+
+    @Test
+    public void saveItemCantFindCategoryTest() throws Exception {
+        ItemInputDto itemDto = new ItemInputDto(4.50, Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci napitak", "sr_SR")
+        ));
+
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.empty());
+
+        Exception ex = Assertions.assertThrows(Exception.class, () -> {
+            itemService.save(2l, itemDto);
+        });
+        Assertions.assertEquals("Selected category doesn't exist!", ex.getMessage());
+    }
+
+    @Test
+    public void saveItemUnknownLanguageTest() throws Exception {
+        Date formatedDate = sdf.parse(sdf.format(new Date()));
+
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+        ItemInputDto itemDto = new ItemInputDto(4.50, Arrays.asList(
+                new ItemTranslationInputDto("lemonade", "fresh summer drink", "en_US"),
+                new ItemTranslationInputDto("limunada", "osvezavajuci napitak", "sr_SR")
+        ));
+        Item itemForSave = new Item(null, formatedDate, formatedDate, 4.50, null, Arrays.asList(
+                new ItemTranslation(null, formatedDate, formatedDate, "lemonade",
+                        "fresh summer drink", null, null),
+                new ItemTranslation(null, formatedDate, formatedDate, "limunada",
+                        "osvezavajuci napitak", null, null)
+        ));
+        Item savedItem = new Item(34l, new Date(),new Date(), 4.50, category, null);
+
+        Mockito.when(languageRepository.findLanguageByCulturalCode(ArgumentMatchers.anyString())).thenReturn(Optional.empty());
+        Mockito.when(itemRepository.save(itemForSave)).thenReturn(savedItem);
+        Mockito.when(itemConverter.toEntity(itemDto)).thenReturn(itemForSave);
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.of(category));
+
+        Exception ex = Assertions.assertThrows(Exception.class, () -> {
+            itemService.save(2l, itemDto);
+        });
+        Assertions.assertEquals("Unknown language!", ex.getMessage());
+    }
+
+    @Test
+    public void saveItemDtoIsNullTest() throws Exception {
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.of(category));
+
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            itemService.save(2l, null);
+        });
+        Assertions.assertInstanceOf(NullPointerException.class, ex);
+    }
+
+    @Test
+    public void getAllItemsSuccessfullyTest() throws Exception {
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+        List<Item> items = Arrays.asList(
+                new Item(34l, new Date(), new Date(), 4.50, category, Arrays.asList(
+                        new ItemTranslation(null, new Date(), new Date(), "lemonade", "fresh summer drink",
+                                new Language(1l, "english", "en_EN"), null),
+                        new ItemTranslation(null, new Date(), new Date(), "limunada", "",
+                                new Language(1l, "serbian", "sr_SR"), null)
+                )),
+                new Item(36l, new Date(), new Date(), 9.10, category, Arrays.asList(
+                        new ItemTranslation(null, new Date(), new Date(), "orange juice", "",
+                                new Language(1l, "english", "en_EN"), null),
+                        new ItemTranslation(null, new Date(), new Date(), "sok od pomorandze", "",
+                                new Language(1l, "serbian", "sr_SR"), null)
+                ))
+        );
+        List<ItemOutputDto> itemsDto = Arrays.asList(
+                new ItemOutputDto(34l, 4.50, Arrays.asList(
+                        new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                        new ItemTranslationOutputDto("limunada", "", "serbian", "sr_SR")
+                )),
+                new ItemOutputDto(36l, 9.10, Arrays.asList(
+                        new ItemTranslationOutputDto("orange juice", "", "english", "en_EN"),
+                        new ItemTranslationOutputDto("sok od pomorandze", "", "serbian", "sr_SR")
+                ))
+        );
+
+        Mockito.when(itemConverter.toDto(ArgumentMatchers.any(Item.class))).thenAnswer(invocation -> {
+            Item entity = invocation.getArgument(0);
+            List<ItemTranslationOutputDto> dtoList = entity.getTranslations()
+                    .stream()
+                    .map(translation -> {
+                        return new ItemTranslationOutputDto(translation.getName(), translation.getDescription(),
+                                translation.getLanguage().getLanguage(), translation.getLanguage().getCulturalCode());
+                    })
+                    .toList();
+            return  new ItemOutputDto(entity.getId(), entity.getPrice(), dtoList);
+        });
+        Mockito.when(itemRepository.findItemsByCategory(category)).thenReturn(items);
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.of(category));
+
+        List<ItemOutputDto> result = itemService.getAll(2l);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertArrayEquals(itemsDto.toArray(), result.toArray());
+    }
+
+    @Test
+    public void getAllItemsCantFindCategoryTest() {
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.empty());
+
+        Exception ex = Assertions.assertThrows(Exception.class, () -> {
+            itemService.getAll(2l);
+        });
+        Assertions.assertEquals("Selected category doesn't exist!", ex.getMessage());
+    }
+
+    @Test
+    public void getAllEmptyListOfItemsTest() throws Exception {
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+
+        Mockito.when(itemRepository.findItemsByCategory(category)).thenReturn(Collections.emptyList());
+        Mockito.when(categoryRepository.findById(2l)).thenReturn(Optional.of(category));
+
+        List<ItemOutputDto> result = itemService.getAll(2l);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertArrayEquals(new ItemOutputDto[0], result.toArray());
+        Assertions.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getItemByIdSuccessfullyTest() throws Exception {
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+        Item item = new Item(34l, new Date(), new Date(), 4.50, category, Arrays.asList(
+                new ItemTranslation(null, new Date(), new Date(), "lemonade", "fresh summer drink",
+                        new Language(1l, "english", "en_EN"), null),
+                new ItemTranslation(null, new Date(), new Date(), "limunada", "",
+                        new Language(1l, "serbian", "sr_SR"), null)
+        ));
+        ItemOutputDto itemDto = new ItemOutputDto(34l, 4.50, Arrays.asList(
+                new ItemTranslationOutputDto("lemonade", "fresh summer drink", "english", "en_EN"),
+                new ItemTranslationOutputDto("limunada", "", "serbian", "sr_SR")
+        ));
+
+        Mockito.when(itemConverter.toDto(item)).thenReturn(itemDto);
+        Mockito.when(itemRepository.findById(34l)).thenReturn(Optional.of(item));
+
+        ItemOutputDto result = itemService.getById(34l);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(itemDto, result);
+    }
+
+    @Test
+    public void getItemFailureTest() {
+        Mockito.when(itemRepository.findById(34l)).thenReturn(Optional.empty());
+
+        Exception ex = Assertions.assertThrows(Exception.class, () -> {
+            itemService.getById(34l);
+        });
+        Assertions.assertEquals("Item doesn't exist!", ex.getMessage());
+    }
+
+    @Test
+    public void deleteItemByIdSuccessfullyTest() throws Exception {
+        Category category = new Category(2l, "soft drinks", "0% alcohol", new Date(), new Date(),
+                null, null, null, null);
+        Item item = new Item(34l, new Date(), new Date(), 4.50, category, Arrays.asList(
+                new ItemTranslation(null, new Date(), new Date(), "lemonade", "fresh summer drink",
+                        new Language(1l, "english", "en_EN"), null),
+                new ItemTranslation(null, new Date(), new Date(), "limunada", "",
+                        new Language(1l, "serbian", "sr_SR"), null)
+        ));
+
+        Mockito.doNothing().when(itemRepository).delete(item);
+        Mockito.when(itemRepository.findById(34l)).thenReturn(Optional.of(item));
+
+        itemService.delete(34l);
+
+        Mockito.verify(itemRepository, Mockito.times(1))
+                .delete(ArgumentMatchers.any(Item.class));
+    }
+
+    @Test
+    public void deleteItemFailureTest() {
+        Mockito.when(itemRepository.findById(34l)).thenReturn(Optional.empty());
+
+        Exception ex = Assertions.assertThrows(Exception.class, () -> {
+            itemService.delete(34l);
+        });
+        Assertions.assertEquals("Item doesn't exist!", ex.getMessage());
+    }
+}


### PR DESCRIPTION
This pull request implements endpoints for the Item entity, including DTOs, repository, service, and controller classes. The changes include:

- Added ItemDTO to represent the data transfer object for Item entities.
- Implemented ItemRepository for database interaction with the Item entity.
- Created ItemService to handle business logic and interact with the repository.
- Added ItemController to define RESTful endpoints for CRUD operations on Item entities.

These changes allow clients to perform CRUD operations on Item entities via HTTP requests. Each endpoint follows RESTful conventions for clarity and consistency.

The following tasks were completed:
- Implemented GET, POST, PUT, and DELETE endpoints for Item entities.
- Added request validation and error handling to ensure data integrity.
- Tested endpoints using unit tests to ensure functionality and correctness.

Please review the changes and provide feedback as necessary. Thank you!